### PR TITLE
Echo class and module path and standardize parameter name

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -12,7 +12,7 @@ However, it can be run directly as a command line tool:
   java \ 
     --module-path <lib-path> \
     --module creek.json.schema.generator/org.creekservice.api.json.schema.generator.JsonSchemaGenerator \
-    --output=some/path
+    --output-directory=some/path
 ```
 
 (Run with `--help` for an up-to-date list of arguments)

--- a/generator/src/main/java/module-info.java
+++ b/generator/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module creek.json.schema.generator {
     requires creek.base.schema;
     requires info.picocli;
     requires org.apache.logging.log4j;
+    requires java.management;
 
     exports org.creekservice.api.json.schema.generator;
 

--- a/generator/src/main/java/org/creekservice/api/json/schema/generator/JsonSchemaGenerator.java
+++ b/generator/src/main/java/org/creekservice/api/json/schema/generator/JsonSchemaGenerator.java
@@ -17,6 +17,8 @@
 package org.creekservice.api.json.schema.generator;
 
 
+import java.lang.management.ManagementFactory;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.creekservice.api.base.type.JarVersion;
@@ -43,7 +45,25 @@ public final class JsonSchemaGenerator {
             LOGGER.info(
                     "JsonSchemaGenerator: "
                             + JarVersion.jarVersion(JsonSchemaGenerator.class).orElse("unknown"));
+            LOGGER.info(classPath());
+            LOGGER.info(modulePath());
             LOGGER.info(options);
         }
+    }
+
+    private static String classPath() {
+        return ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+                .filter(
+                        arg ->
+                                arg.startsWith("--class-path")
+                                        || arg.startsWith("-classpath")
+                                        || arg.startsWith("-cp"))
+                .collect(Collectors.joining(" "));
+    }
+
+    private static String modulePath() {
+        return ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+                .filter(arg -> arg.startsWith("--module-path") || arg.startsWith("-p"))
+                .collect(Collectors.joining(" "));
     }
 }

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/PicoCliParser.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/PicoCliParser.java
@@ -70,7 +70,7 @@ public final class PicoCliParser {
         private boolean echoOnly;
 
         @Option(
-                names = {"-o", "--output"},
+                names = {"-o", "--output-directory"},
                 required = true,
                 description = "The directory the schemas will be written to.")
         private Path outputDirectory;
@@ -99,7 +99,7 @@ public final class PicoCliParser {
 
         @Override
         public String toString() {
-            return "--output="
+            return "--output-directory="
                     + outputDirectory
                     + lineSeparator()
                     + "--package="

--- a/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorFunctionalTest.java
+++ b/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorFunctionalTest.java
@@ -64,7 +64,7 @@ class JsonSchemaGeneratorFunctionalTest {
         assertThat(stdOut.get(), startsWith("Usage: JsonSchemaGenerator"));
         assertThat(
                 stdOut.get(), containsString("-h, --help      Show this help message and exit."));
-        assertThat(stdOut.get(), containsString("-o, --output=<outputDirectory>"));
+        assertThat(stdOut.get(), containsString("-o, --output-directory=<outputDirectory>"));
         assertThat(exitCode, is(0));
     }
 
@@ -93,7 +93,8 @@ class JsonSchemaGeneratorFunctionalTest {
         // Then:
         assertThat(stdErr.get(), is(""));
         assertThat(stdOut.get(), matchesPattern(VERSION_PATTERN));
-        assertThat(stdOut.get(), containsString("--output=some/path"));
+        assertThat(stdOut.get(), containsString("--module-path=" + LIB_DIR));
+        assertThat(stdOut.get(), containsString("--output-directory=some/path"));
         assertThat(stdOut.get(), containsString("--package=<Not Set>"));
         assertThat(exitCode, is(0));
     }
@@ -146,7 +147,7 @@ class JsonSchemaGeneratorFunctionalTest {
     }
 
     private static String[] minimalArgs(final String... additional) {
-        final List<String> args = new ArrayList<>(List.of("--output=some/path"));
+        final List<String> args = new ArrayList<>(List.of("--output-directory=some/path"));
         args.addAll(List.of(additional));
         return args.toArray(String[]::new);
     }

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/PicoCliParserTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/PicoCliParserTest.java
@@ -119,11 +119,15 @@ class PicoCliParserTest {
         // Then:
         assertThat(
                 result.map(Object::toString),
-                is(Optional.of("--output=some/path" + lineSeparator() + "--package=<Not Set>")));
+                is(
+                        Optional.of(
+                                "--output-directory=some/path"
+                                        + lineSeparator()
+                                        + "--package=<Not Set>")));
     }
 
     private static String[] minimalArgs(final String... additional) {
-        final List<String> args = new ArrayList<>(List.of("--output=some/path"));
+        final List<String> args = new ArrayList<>(List.of("--output-directory=some/path"));
         args.addAll(List.of(additional));
         return args.toArray(String[]::new);
     }


### PR DESCRIPTION
Now loads class & module paths on `--echo-only`, to enable testing of plugins.
Changes `--output` parameter to `--output-directory` to standardize with the system test generator param naming

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended