### PR TITLE
Add subtype scanning module filter and add common `TypeScanning` type.

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -440,21 +440,30 @@ properties:
     type: string
 ```
 
-## Java Modules
+## Type Scanning
 
-The generator can be run as a Java Module.
+The generator scans the class path to: 
 
-When running under JPMS, Java Platform Module System, the search for `@GeneratesSchema` annotated types can be limited
-to one or more specific modules. (See the `--alllowed-module` command line argument and/or the `GeneratorOptions.
-allowedModules()` method). This can speed up the generation of schemas and avoid writing schemas for annotated types
-in dependencies.
+1. find types that require a schema generated, i.e. those annotated with `@GeneratesSchema`.
+2. find subtypes of any polymorphic types it encounters that do not define an explicit set of subtypes, i.e. types
+   annotated with `@JsonTypeInfo`, but not `@JsonSubTypes`.
 
-When not running under JPMS the `--allowed-base-type-package` command line argument and/or the `GeneratorOptions.
-allowedBaseTypePackages()` methods can be used to speed up the search of the class path and to avoid generating
-schemas for annotated types found in dependencies.
+By default, scans include the full class and module paths.  Such scans can be relatively slow *and* can result in 
+unwanted schema generation, e.g. generating schema files for types found in dependencies.
 
-When running under JPMS, it is also necessary to `export` all model types to `com.fasterxml.jackson.databind`. This is
-required to allow [Jackson][4] to work its magic and walk the object model:
+Type scanning can be restricted by JPMS module name and/or Java package name. Both module and package names can include
+the glob wildcard {@code *} character.
+
+Type scanning, i.e. scanning for `@GeneratesSchema`, can be restricted using the `--type-scanning-allowed-module`
+and `--type-scanning-allowed-package` command line parameters. Subtype scanning can be restricted using 
+the `--subtype-scanning-allowed-module` and `--subtype-scanning-allowed-package` command line parameters. All of these
+parameters can be specified multiple times on the command line to add multiple allowed module or package names.
+
+### Running under JPMS
+
+When running under JPMS, Java Platform Modular System, it is necessary to `export` all packages contained 
+`@GeneratesSchema` annotated types to `com.fasterxml.jackson.databind`. This is required to allow [Jackson][4] to work 
+its magic and walk the object model. For example:
 
 ```java
 module acme.model {

--- a/generator/src/main/java/org/creekservice/api/json/schema/generator/GeneratorOptions.java
+++ b/generator/src/main/java/org/creekservice/api/json/schema/generator/GeneratorOptions.java
@@ -23,6 +23,61 @@ import java.util.Set;
 /** Options to control the {@link JsonSchemaGenerator}. */
 public interface GeneratorOptions {
 
+    interface TypeScanningSpec {
+        /**
+         * The list of module names used to limit type scanning to only the specified modules.
+         *
+         * <p>Allowed module names can include the glob wildcard {@code *} character.
+         *
+         * <p>Default: empty, meaning all modules will be scanned.
+         */
+        default Set<String> moduleWhiteList() {
+            return Set.of();
+        }
+
+        /**
+         * The list of package name used to limit type scanning to only the specified packages.
+         *
+         * <p>Allowed package names can include the glob wildcard {@code *} character.
+         *
+         * <p>Default: empty, meaning all packages will be scanned.
+         */
+        default Set<String> packageWhiteList() {
+            return Set.of();
+        }
+    }
+
+    /**
+     * Configure type scanning for finding types to generate schema for, i.e. types annotated with
+     * {@link org.creekservice.api.base.annotation.schema.GeneratesSchema}.
+     *
+     * <p>By default, the full class and model path are scanned for types to generate schemas for
+     * i.e. types annotated with {@link
+     * org.creekservice.api.base.annotation.schema.GeneratesSchema}. Scan time can be reduced and
+     * unwanted types excluded, e.g. types in dependencies, by configuring the subtype scanning.
+     *
+     * @return the type scanning config
+     */
+    default TypeScanningSpec typeScanning() {
+        return new TypeScanningSpec() {};
+    }
+
+    /**
+     * Configure type scanning for finding subtypes, i.e. subtypes of polymorphic types that are
+     * part of base types.
+     *
+     * <p>By default, the full class and model path are scanned for subtypes when generating the
+     * schema for polymorphic types that do not define an explicit set of subtypes, i.e. types
+     * annotated with {@code @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)}, but not with
+     * {@code @JsonSubTypes}. Scan time can be reduced and unwanted subtypes excluded by configuring
+     * the subtype scanning.
+     *
+     * @return the type scanning config
+     */
+    default TypeScanningSpec subTypeScanning() {
+        return new TypeScanningSpec() {};
+    }
+
     /**
      * @return If set, the generator will parse and echo its arguments and exit. Useful for testing.
      */
@@ -32,52 +87,4 @@ public interface GeneratorOptions {
 
     /** @return The directory to output schema files to. */
     Path outputDirectory();
-
-    /**
-     * Allowed modules.
-     *
-     * <p>By default, schemas are generated for all types annotated with {@link
-     * org.creekservice.api.base.annotation.schema.GeneratesSchema}. Specifying one or more allowed
-     * modules restricts the returned types that belong to one of the supplied modules.
-     *
-     * <p>To use this feature the generator must be run from the module path, i.e. under JPMS.
-     *
-     * <p>Allowed module names can include the glob wildcard {@code *} character.
-     *
-     * @return allowed modules. If empty, all modules are allowed.
-     */
-    default Set<String> allowedModules() {
-        return Set.of();
-    }
-
-    /**
-     * Allowed packages for base types.
-     *
-     * <p>By default, schemas are generated for all types annotated with {@link
-     * org.creekservice.api.base.annotation.schema.GeneratesSchema}. Specifying one or more allowed
-     * base type packages restricts the returned types to only those under the supplied packages.
-     *
-     * <p>Allowed package names can include the glob wildcard {@code *} character.
-     *
-     * @return allowed base type packages. If empty, all packages are allowed.
-     */
-    default Set<String> allowedBaseTypePackages() {
-        return Set.of();
-    }
-
-    /**
-     * Allowed packages for subtypes.
-     *
-     * <p>By default, all subtypes are used when generating the schema for a type annotated with
-     * {@code @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)}. Specifying one or more allowed subtype
-     * packages restricts the subtypes included in the schema to only those under the supplied
-     * packages.
-     *
-     * <p>Allowed package names can include the glob wildcard {@code *} character.
-     *
-     * @return allowed subtype packages. If empty, all packages are allowed.
-     */
-    default Set<String> allowedSubTypePackages() {
-        return Set.of();
-    }
 }

--- a/generator/src/main/java/org/creekservice/api/json/schema/generator/JsonSchemaGenerator.java
+++ b/generator/src/main/java/org/creekservice/api/json/schema/generator/JsonSchemaGenerator.java
@@ -70,11 +70,11 @@ public final class JsonSchemaGenerator {
 
         final Set<Class<?>> types =
                 GeneratesSchemas.scanner()
-                        .withAllowedPackages(options.allowedBaseTypePackages())
-                        .withAllowedModules(options.allowedModules())
+                        .withAllowedModules(options.typeScanning().moduleWhiteList())
+                        .withAllowedPackages(options.typeScanning().packageWhiteList())
                         .scan();
 
-        final SchemaGenerator generator = new SchemaGenerator(options.allowedSubTypePackages());
+        final SchemaGenerator generator = new SchemaGenerator(options.subTypeScanning());
         final SchemaWriter writer = new SchemaWriter(options.outputDirectory());
         generator.registerSubTypes(types);
         types.stream().map(generator::generateSchema).forEach(writer::write);

--- a/generator/src/test/java/org/creekservice/api/json/schema/generator/GeneratorOptionsTest.java
+++ b/generator/src/test/java/org/creekservice/api/json/schema/generator/GeneratorOptionsTest.java
@@ -38,17 +38,22 @@ class GeneratorOptionsTest {
     }
 
     @Test
-    void shouldDefaultToNotFilteringByModule() {
-        assertThat(options.allowedModules(), is(empty()));
+    void shouldDefaultToNotFilteringTypeScanningModules() {
+        assertThat(options.typeScanning().moduleWhiteList(), is(empty()));
     }
 
     @Test
-    void shouldDefaultToNotFilteringBaseTypePackages() {
-        assertThat(options.allowedBaseTypePackages(), is(empty()));
+    void shouldDefaultToNotFilteringTypeScanningPackages() {
+        assertThat(options.typeScanning().packageWhiteList(), is(empty()));
     }
 
     @Test
-    void shouldDefaultToNotFilteringSubTypePackages() {
-        assertThat(options.allowedSubTypePackages(), is(empty()));
+    void shouldDefaultToNotFilteringSubTypeScanningModules() {
+        assertThat(options.subTypeScanning().moduleWhiteList(), is(empty()));
+    }
+
+    @Test
+    void shouldDefaultToNotFilteringSubTypeScanningPackages() {
+        assertThat(options.subTypeScanning().packageWhiteList(), is(empty()));
     }
 }

--- a/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorFunctionalTest.java
+++ b/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorFunctionalTest.java
@@ -150,7 +150,8 @@ class JsonSchemaGeneratorFunctionalTest {
                         "--module",
                         "creek.json.schema.generator/org.creekservice.api.json.schema.generator.JsonSchemaGenerator",
                         "--output-directory=" + outputDir.toAbsolutePath(),
-                        "--allowed-module=creek.json.schema.test.types"));
+                        "--type-scanning-allowed-module=creek.json.schema.test.types",
+                        "--subtype-scanning-allowed-module=creek.json.schema.test.types"));
         return cmd;
     }
 

--- a/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorTest.java
+++ b/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorTest.java
@@ -90,7 +90,7 @@ class JsonSchemaGeneratorTest {
     @Test
     void shouldEchoArguments() {
         // Given:
-        final String[] args = minimalArgs("--echo-only", "-btp=some.*.package");
+        final String[] args = minimalArgs("--echo-only", "-p=some.*.package");
 
         // When:
         final int exitCode = runExecutor(args);
@@ -99,9 +99,11 @@ class JsonSchemaGeneratorTest {
         assertThat(stdErr.get(), is(""));
         assertThat(stdOut.get(), matchesPattern(VERSION_PATTERN));
         assertThat(stdOut.get(), containsString("--output-directory=some/path"));
-        assertThat(stdOut.get(), containsString("--allowed-modules=<ANY>"));
-        assertThat(stdOut.get(), containsString("--allowed-base-type-packages=[some.*.package]"));
-        assertThat(stdOut.get(), containsString("--allowed-sub-type-packages=<ANY>"));
+        assertThat(stdOut.get(), containsString("--type-scanning-allowed-modules=<ANY>"));
+        assertThat(
+                stdOut.get(), containsString("--type-scanning-allowed-packages=[some.*.package]"));
+        assertThat(stdOut.get(), containsString("--subtype-scanning-allowed-modules=<ANY>"));
+        assertThat(stdOut.get(), containsString("--subtype-scanning-allowed-packages=<ANY>"));
         assertThat(exitCode, is(0));
     }
 

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/cli/PicoCliParserTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/cli/PicoCliParserTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.creekservice.api.json.schema.generator.GeneratorOptions;
+import org.creekservice.api.json.schema.generator.GeneratorOptions.TypeScanningSpec;
 import org.junit.jupiter.api.Test;
 
 class PicoCliParserTest {
@@ -96,47 +97,67 @@ class PicoCliParserTest {
     }
 
     @Test
-    void shouldParseAllowedModule() {
+    void shouldParseTypeScanningAllowedModule() {
         // Given:
-        final String[] args = minimalArgs("--allowed-module=some.module", "-m=another.module");
+        final String[] args =
+                minimalArgs("--type-scanning-allowed-module=some.module", "-m=another.module");
 
         // When:
         final Optional<GeneratorOptions> result = PicoCliParser.parse(args);
 
         // Then:
         assertThat(
-                result.map(GeneratorOptions::allowedModules),
+                result.map(GeneratorOptions::typeScanning).map(TypeScanningSpec::moduleWhiteList),
                 is(Optional.of(Set.of("some.module", "another.module"))));
     }
 
     @Test
-    void shouldParseAllowedBaseTypePackage() {
+    void shouldParseTypeScanningAllowedPackage() {
         // Given:
         final String[] args =
                 minimalArgs(
-                        "--allowed-base-type-package=some.package.name", "-btp=another.package");
+                        "--type-scanning-allowed-package=some.package.name", "-p=another.package");
 
         // When:
         final Optional<GeneratorOptions> result = PicoCliParser.parse(args);
 
         // Then:
         assertThat(
-                result.map(GeneratorOptions::allowedBaseTypePackages),
+                result.map(GeneratorOptions::typeScanning).map(TypeScanningSpec::packageWhiteList),
                 is(Optional.of(Set.of("some.package.name", "another.package"))));
     }
 
     @Test
-    void shouldParseAllowedSubTypePackage() {
+    void shouldParseSubtypeScanningAllowedModule() {
         // Given:
         final String[] args =
-                minimalArgs("--allowed-sub-type-package=some.package.name", "-stp=another.package");
+                minimalArgs("--subtype-scanning-allowed-module=some.module", "-sm=another.module");
 
         // When:
         final Optional<GeneratorOptions> result = PicoCliParser.parse(args);
 
         // Then:
         assertThat(
-                result.map(GeneratorOptions::allowedSubTypePackages),
+                result.map(GeneratorOptions::subTypeScanning)
+                        .map(TypeScanningSpec::moduleWhiteList),
+                is(Optional.of(Set.of("some.module", "another.module"))));
+    }
+
+    @Test
+    void shouldParseSubtypeScanningAllowedPackage() {
+        // Given:
+        final String[] args =
+                minimalArgs(
+                        "--subtype-scanning-allowed-package=some.package.name",
+                        "-sp=another.package");
+
+        // When:
+        final Optional<GeneratorOptions> result = PicoCliParser.parse(args);
+
+        // Then:
+        assertThat(
+                result.map(GeneratorOptions::subTypeScanning)
+                        .map(TypeScanningSpec::packageWhiteList),
                 is(Optional.of(Set.of("some.package.name", "another.package"))));
     }
 
@@ -155,11 +176,13 @@ class PicoCliParserTest {
                         Optional.of(
                                 "--output-directory=some/path"
                                         + lineSeparator()
-                                        + "--allowed-modules=[some.module]"
+                                        + "--type-scanning-allowed-modules=[some.module]"
                                         + lineSeparator()
-                                        + "--allowed-base-type-packages=<ANY>"
+                                        + "--type-scanning-allowed-packages=<ANY>"
                                         + lineSeparator()
-                                        + "--allowed-sub-type-packages=<ANY>")));
+                                        + "--subtype-scanning-allowed-modules=<ANY>"
+                                        + lineSeparator()
+                                        + "--subtype-scanning-allowed-packages=<ANY>")));
     }
 
     private static String[] minimalArgs(final String... additional) {


### PR DESCRIPTION
It's already possible to limit the main scan for schema types by module name. Add the same functionality for subtype scans.

This then highlights a common pattern for both types of scans:  filter by module and filter by package. So move this into its own type.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended