### PR TITLE
Fix logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,7 +88,8 @@ subprojects {
         testImplementation("org.hamcrest:hamcrest-core:$hamcrestVersion")
         testImplementation("com.google.guava:guava-testlib:$guavaVersion")
         testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
-        testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion")
+        // An old v1.x SLF4J impl as required by mbknor-jackson-jsonschema
+        testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     }
 

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -37,7 +37,8 @@ dependencies {
     implementation("com.kjetland:mbknor-jackson-jsonschema_2.13:$jsonSchemaVersion")
     implementation("io.github.classgraph:classgraph:$classGraphVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
-    runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
+    // An old v1.x SLF4J impl as required by mbknor-jackson-jsonschema
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
 
     testImplementation(project(":test-types"))
 }


### PR DESCRIPTION
`mbknor-jackson-jsonschema` dependency is still on pre-`2.0.0` SLF4J api. Using `2.0.0` causes things to fail with a `ClassDefNotFound` exception :(

Raised https://github.com/mbknor/mbknor-jackson-jsonSchema/pull/172

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended