### PR TITLE
Force dependency versions to fix security vulnerabilities in dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: gradle
     directory: /
     registries:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew javadoc check coveralls
+        run: ./gradlew build coveralls
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish_artifacts == 'true'
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,12 +31,13 @@ subprojects {
         set("jacksonVersion", "2.14.1")         // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
         set("jsonSchemaVersion", "1.0.39")      // https://mvnrepository.com/artifact/com.kjetland/mbknor-jackson-jsonschema
         set("classGraphVersion", "4.8.154")     // https://mvnrepository.com/artifact/io.github.classgraph/classgraph
+        set("kotlinVersion", "1.7.22")          // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib-common
 
         set("log4jVersion", "2.19.0")           // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
         set("guavaVersion", "31.1-jre")         // https://mvnrepository.com/artifact/com.google.guava/guava
         set("junitVersion", "5.9.2")            // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
         set("junitPioneerVersion", "1.9.1")     // https://mvnrepository.com/artifact/org.junit-pioneer/junit-pioneer
-        set("mockitoVersion", "4.11.0")          // https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
+        set("mockitoVersion", "4.11.0")         // https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
         set("hamcrestVersion", "2.2")           // https://mvnrepository.com/artifact/org.hamcrest/hamcrest-core
     }
 
@@ -47,6 +48,7 @@ subprojects {
     val junitPioneerVersion: String by extra
     val mockitoVersion: String by extra
     val hamcrestVersion : String by extra
+    val kotlinVersion : String by extra
 
     dependencies {
         testImplementation("org.creekservice:creek-test-hamcrest:$creekVersion")
@@ -60,8 +62,27 @@ subprojects {
         testImplementation("com.google.guava:guava-testlib:$guavaVersion")
         testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
         // An old v1.x SLF4J impl as required by mbknor-jackson-jsonschema
+        // Can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/pull/172 is resolved:
         testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    }
+
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            // Can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/174 is resolved:
+            if (requested.group == "org.scala-lang" && requested.name == "scala-library") {
+                useVersion("2.13.10")
+                because("security vulnerabilities found < 2.13.9: " +
+                        "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36944")
+            }
+
+            // Can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/178 is resolved:
+            if (requested.group == "org.jetbrains.kotlin" && requested.name == "kotlin-scripting-compiler-embeddable") {
+                useVersion(kotlinVersion)
+                because("security vulnerabilities found in 1.3.50: " +
+                        "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24329")
+            }
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -17,7 +17,7 @@
 /**
  * Standard configuration of Creek projects
  *
- * <p>Version: 1.2
+ * <p>Version: 1.3
  *
  * <p>Apply to all java modules, usually excluding the root project in multi-module sets.
  */
@@ -32,8 +32,9 @@ plugins {
 group = "org.creekservice"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
@@ -43,7 +43,7 @@ pluginBundle {
     website = "https://www.creekservice.org/${rootProject.name}"
     vcsUrl = "https://github.com/creek-service/${rootProject.name}"
 
-    tags = listOf("creek", "creekservice", "microservice", "docker", "containers")
+    tags = listOf("creek", "creekservice")
 }
 
 if (prependRootName) {

--- a/test-types/build.gradle.kts
+++ b/test-types/build.gradle.kts
@@ -22,11 +22,12 @@ plugins {
 val creekVersion : String by extra
 val jacksonVersion : String by extra
 val jsonSchemaVersion : String by extra
+val kotlinVersion : String by extra
 
 dependencies {
     implementation("org.creekservice:creek-base-annotation:$creekVersion")
     implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
     implementation("com.kjetland:mbknor-jackson-jsonschema_2.13:$jsonSchemaVersion")
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
 }


### PR DESCRIPTION
- Fixes scala version at `2.13.10`
- Fixes Kotlin version at `1.7.22`, (down from `1.8.0` which isn't supported by CodeQL yet).

See https://sbom.lift.sonatype.com/report/T1-a0368c8f29fdaa555824-89a20518f39cd-1673481850-0b331e440852477381e481142d50e92c for more info

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
