### PR TITLE
Bump Kotlin libraries to `1.7.22`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ subprojects {
         set("jacksonVersion", "2.14.1")         // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
         set("jsonSchemaVersion", "1.0.39")      // https://mvnrepository.com/artifact/com.kjetland/mbknor-jackson-jsonschema
         set("classGraphVersion", "4.8.154")     // https://mvnrepository.com/artifact/io.github.classgraph/classgraph
+        set("kotlinVersion", "1.7.22")          // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib-common
 
         set("log4jVersion", "2.19.0")           // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
         set("guavaVersion", "31.1-jre")         // https://mvnrepository.com/artifact/com.google.guava/guava
@@ -47,6 +48,7 @@ subprojects {
     val junitPioneerVersion: String by extra
     val mockitoVersion: String by extra
     val hamcrestVersion : String by extra
+    val kotlinVersion : String by extra
 
     dependencies {
         testImplementation("org.creekservice:creek-test-hamcrest:$creekVersion")
@@ -72,6 +74,13 @@ subprojects {
                 useVersion("2.13.10")
                 because("security vulnerabilities found < 2.13.9: " +
                         "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36944")
+            }
+
+            // Can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/178 is resolved:
+            if (requested.group == "org.jetbrains.kotlin" && requested.name == "kotlin-scripting-compiler-embeddable") {
+                useVersion(kotlinVersion)
+                because("security vulnerabilities found in 1.3.50: " +
+                        "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24329")
             }
         }
     }

--- a/test-types/build.gradle.kts
+++ b/test-types/build.gradle.kts
@@ -22,11 +22,12 @@ plugins {
 val creekVersion : String by extra
 val jacksonVersion : String by extra
 val jsonSchemaVersion : String by extra
+val kotlinVersion : String by extra
 
 dependencies {
     implementation("org.creekservice:creek-base-annotation:$creekVersion")
     implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
     implementation("com.kjetland:mbknor-jackson-jsonschema_2.13:$jsonSchemaVersion")
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.22")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
 }


### PR DESCRIPTION
This updates Kotlin to a version beyond security vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2020-29582


### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
