### PR TITLE
Update transitive dependencies with security vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ registries:
 updates:
   - package-ecosystem: github-actions
     directory: /
+    open-pull-requests-limit: 50
     schedule:
       interval: monthly
   - package-ecosystem: gradle
@@ -23,5 +24,6 @@ updates:
     registries:
       - maven-snapshots
       - creek-github-packages
+    open-pull-requests-limit: 50
     schedule:
       interval: monthly

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ subprojects {
         set("jsonSchemaVersion", "1.0.39")      // https://mvnrepository.com/artifact/com.kjetland/mbknor-jackson-jsonschema
         set("classGraphVersion", "4.8.154")     // https://mvnrepository.com/artifact/io.github.classgraph/classgraph
         set("kotlinVersion", "1.7.22")          // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib-common
+        set("scalaVersion", "2.13.10")
 
         set("log4jVersion", "2.19.0")           // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
         set("guavaVersion", "31.1-jre")         // https://mvnrepository.com/artifact/com.google.guava/guava
@@ -48,7 +49,6 @@ subprojects {
     val junitPioneerVersion: String by extra
     val mockitoVersion: String by extra
     val hamcrestVersion : String by extra
-    val kotlinVersion : String by extra
 
     dependencies {
         testImplementation("org.creekservice:creek-test-hamcrest:$creekVersion")
@@ -65,24 +65,6 @@ subprojects {
         // Can be updated once https://github.com/mbknor/mbknor-jackson-jsonSchema/pull/172 is resolved:
         testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    }
-
-    configurations.all {
-        resolutionStrategy.eachDependency {
-            // Can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/174 is resolved:
-            if (requested.group == "org.scala-lang" && requested.name == "scala-library") {
-                useVersion("2.13.10")
-                because("security vulnerabilities found < 2.13.9: " +
-                        "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36944")
-            }
-
-            // Can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/178 is resolved:
-            if (requested.group == "org.jetbrains.kotlin" && requested.name == "kotlin-scripting-compiler-embeddable") {
-                useVersion(kotlinVersion)
-                because("security vulnerabilities found in 1.3.50: " +
-                        "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24329")
-            }
-        }
     }
 }
 

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -26,6 +26,8 @@ val log4jVersion : String by extra
 val jacksonVersion : String by extra
 val jsonSchemaVersion : String by extra
 val classGraphVersion : String by extra
+val scalaVersion : String by extra
+val kotlinVersion : String by extra
 
 dependencies {
     implementation("org.creekservice:creek-base-annotation:$creekVersion")
@@ -42,6 +44,14 @@ dependencies {
     // An old v1.x SLF4J impl as required by mbknor-jackson-jsonschema
     // Can be updated once https://github.com/mbknor/mbknor-jackson-jsonSchema/pull/172 is resolved:
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
+
+    // The following are set to bring in dependency versions beyond known security vulnerabilities:
+    // The following can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/174 is resolved:
+    // Also see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36944
+    implementation("org.scala-lang:scala-library:$scalaVersion")
+    // The following can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/178 is resolved:
+    // Also see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24329
+    implementation("org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$kotlinVersion")
 
     testImplementation(project(":test-types"))
 }

--- a/test-types/build.gradle.kts
+++ b/test-types/build.gradle.kts
@@ -23,6 +23,7 @@ val creekVersion : String by extra
 val jacksonVersion : String by extra
 val jsonSchemaVersion : String by extra
 val kotlinVersion : String by extra
+val scalaVersion : String by extra
 
 dependencies {
     implementation("org.creekservice:creek-base-annotation:$creekVersion")
@@ -30,4 +31,12 @@ dependencies {
     implementation("com.kjetland:mbknor-jackson-jsonschema_2.13:$jsonSchemaVersion")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
+
+    // The following are set to bring in dependency versions beyond known security vulnerabilities:
+    // The following can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/174 is resolved:
+    // Also see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36944
+    implementation("org.scala-lang:scala-library:$scalaVersion")
+    // The following can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/178 is resolved:
+    // Also see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24329
+    implementation("org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$kotlinVersion")
 }


### PR DESCRIPTION
* Update `org.scala-lang:scala-library` to `2.13.10`, as previous versions suffered from  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36944. Raised https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/174 to address.
* Update `org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable` to `1.7.22`, as previous versions suffered from https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24329. Raised https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/178  to address

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
