### PR TITLE
Fix dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,6 @@ subprojects {
         // An old v1.x SLF4J impl as required by mbknor-jackson-jsonschema
         // Can be updated once https://github.com/mbknor/mbknor-jackson-jsonSchema/pull/172 is resolved:
         testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
-        testRuntimeOnly("org.slf4j:slf4j-api:2.0.9")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     }
 }

--- a/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
@@ -95,9 +95,9 @@ publishing {
             name.set("${project.group}:${artifactId}")
 
             if (prependRootName) {
-                description.set("${rootProject.name.capitalize()} ${project.name} library".replace("-", " "))
+                description.set("${rootProject.name} ${project.name} library".replace("-", " "))
             } else {
-                description.set("${project.name.capitalize()} library".replace("-", " "))
+                description.set("${project.name} library".replace("-", " "))
             }
 
             url.set("https://www.creekservice.org")

--- a/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
@@ -78,9 +78,9 @@ publishing {
                 name.set("${project.group}:${artifactId}")
 
                 if (prependRootName) {
-                    description.set("${rootProject.name.capitalize()} ${project.name} library".replace("-", " "))
+                    description.set("${rootProject.name} ${project.name} library".replace("-", " "))
                 } else {
-                    description.set("${project.name.capitalize()} library".replace("-", " "))
+                    description.set("${project.name} library".replace("-", " "))
                 }
 
                 url.set("https://www.creekservice.org")

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     // An old v1.x SLF4J impl as required by mbknor-jackson-jsonschema
     // Can be updated once https://github.com/mbknor/mbknor-jackson-jsonSchema/pull/172 is resolved:
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
+    runtimeOnly("org.slf4j:slf4j-api:2.0.9")
 
     // The following are set to bring in dependency versions beyond known security vulnerabilities:
     // The following can be removed once https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/174 is resolved:


### PR DESCRIPTION
log4j 2.21.x changed around module names, this has caused issues with dependencies.

It looks like the slf4j api module is required on the classpath, even though the jar is not actively used.
