### PR TITLE
Ensure output file links can be clicked.

### DIFF
--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/SchemaWriter.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/SchemaWriter.java
@@ -62,7 +62,7 @@ public final class SchemaWriter {
                     type.getCanonicalName() == null
                             ? type.getSimpleName()
                             : type.getCanonicalName();
-            LOGGER.info("Wrote {}'s schema to {}", name, path);
+            LOGGER.info("Wrote {}'s schema to {}", name, path.toUri());
         } catch (final Exception e) {
             throw new GenerateSchemaException("Failed to write schema for " + type, e);
         }


### PR DESCRIPTION
Before this change some paths output to the console were not being picked up and highlighted by IntelliJ, making it tiresome to locate the schema file.
