### PR TITLE
Use standard Jackson-compatible subtype names

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -228,12 +228,12 @@ For example:
 @GeneratesSchema
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = SubType1.class, name = "type_1"),
-        @JsonSubTypes.Type(value = SubType2.class, name = "type_2")
+        @JsonSubTypes.Type(value = ExplicitlyNamedType.class, name = "type_1"),
+        @JsonSubTypes.Type(value = ImplicitlyNamedType.class)
 })
 public interface PolymorphicModel {}
 
-public class SubType1 implements PolymorphicModel {
+public class ExplicitlyNamedType implements PolymorphicModel {
     public String getProp1() {
         // ...
     }
@@ -254,8 +254,8 @@ private class SubType2 implements PolymorphicModel {
 $schema: http://json-schema.org/draft-07/schema#
 title: Polymorphic Model
 oneOf:
-  - $ref: '#/definitions/SubType1'
-  - $ref: '#/definitions/SubType2'
+  - $ref: '#/definitions/ExplicitlyNamedType'
+  - $ref: '#/definitions/ImplicitlyNamedType'
 definitions:
   SubType1:
     type: object
@@ -278,11 +278,11 @@ definitions:
       '@type':
         type: string
         enum:
-          - type_2
-        default: type_2
+          - ImplicitlyNamedType
+        default: ImplicitlyNamedType
       prop2:
         type: string
-    title: type_2
+    title: ImplicitlyNamedType
     required:
       - '@type'
 ```
@@ -290,7 +290,7 @@ definitions:
 ##### Subtype discovery
 
 The generator will search the class and module paths for subtypes of any polymorphic types that are annotated without 
-a  `@JsonSubTypes` annotation to define explicit subtypes.
+a  `@JsonSubTypes` annotation to define explicit subtypes, using [ClassGraph](https://github.com/classgraph/classgraph).
 
 For example:
 
@@ -300,6 +300,7 @@ For example:
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 public interface Thing {}
 
+@JsonTypeName("big")
 public class BigThing implements Thing {
     public String getProp1() {
         // ...
@@ -322,7 +323,7 @@ $schema: http://json-schema.org/draft-07/schema#
 title: Thing
 oneOf:
   - $ref: '#/definitions/SmallThing'
-  - $ref: '#/definitions/BigThing'
+  - $ref: '#/definitions/big'
 definitions:
   SmallThing:
     type: object
@@ -331,10 +332,10 @@ definitions:
       '@type':
         type: string
         enum:
-          - small
-        default: small
+          - SmallThing
+        default: SmallThing
       prop2:
-        type: string
+        type: SmallThing
     title: small
     required:
       - '@type'

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/PolymorphicTypes.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/PolymorphicTypes.java
@@ -158,7 +158,7 @@ final class PolymorphicTypes {
 
         // Visit subtypes:
         for (final Class<? extends T> subType : poly.subTypes()) {
-            // Optimisation: subtypes already found for parent, which is super set of sub type:
+            // Optimisation: subtypes already found for parent, which is super set of subtype:
             found.put(subType, new PolymorphicType<>(subType, Set.of()));
 
             visitType(subType);
@@ -168,7 +168,9 @@ final class PolymorphicTypes {
     @SuppressWarnings({"unchecked", "rawtypes"})
     private <T> List<Class<? extends T>> implementationsOf(final Class<T> type) {
         final JsonTypeInfo typeInfo = type.getAnnotation(JsonTypeInfo.class);
-        if (typeInfo == null || typeInfo.use() != JsonTypeInfo.Id.NAME) {
+        if (typeInfo == null
+                || (typeInfo.use() != JsonTypeInfo.Id.NAME
+                        && typeInfo.use() != JsonTypeInfo.Id.SIMPLE_NAME)) {
             // Not using registered types
             return List.of();
         }

--- a/generator/src/test/resources/test/types/org.creekservice.test.types.thing.yml
+++ b/generator/src/test/resources/test/types/org.creekservice.test.types.thing.yml
@@ -4,7 +4,7 @@ $schema: http://json-schema.org/draft-07/schema#
 title: Thing
 oneOf:
 - $ref: '#/definitions/SmallThing'
-- $ref: '#/definitions/BigThing'
+- $ref: '#/definitions/big'
 definitions:
   SmallThing:
     type: object
@@ -13,14 +13,14 @@ definitions:
       '@type':
         type: string
         enum:
-        - small
-        default: small
+        - Thing$SmallThing
+        default: Thing$SmallThing
       prop2:
         type: string
-    title: small
+    title: Thing$SmallThing
     required:
     - '@type'
-  BigThing:
+  big:
     type: object
     additionalProperties: false
     properties:

--- a/test-types/src/main/java/org/creekservice/test/types/Thing.java
+++ b/test-types/src/main/java/org/creekservice/test/types/Thing.java
@@ -17,6 +17,7 @@
 package org.creekservice.test.types;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.creekservice.api.base.annotation.schema.GeneratesSchema;
 
 @SuppressWarnings("unused") // Invoked via reflection
@@ -24,6 +25,7 @@ import org.creekservice.api.base.annotation.schema.GeneratesSchema;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 public interface Thing {
 
+    @JsonTypeName("big")
     class BigThing implements Thing {
         public String getProp1() {
             return null;


### PR DESCRIPTION
...as it just makes things easier and Jackson already provides a way to customise.

Also, add support for `JsonTypeInfo.Id.SIMPLE_NAME`.

BREAKING CHANGE:

Changing the subtype name in the schema is a breaking change. Regenerating a schema that uses polymorphism using `@JsonTypeInfo` with `uses` set to `JsonTypeInfo.Id.NAME`, but without `@JsonSubTypes` defined, will result in a different schema being produced.

However, the previously generated schema wasn't compatible with the JSON Jackson would have produced. Where as it now is.

Also, it's possible to annotate subtypes with `@JsonTypeName` to specify an exact logical name to use in both the schema and in the JSON.


