### PR TITLE
JPMS compatible schema output paths.

### DIFF
--- a/generator/src/main/java/org/creekservice/api/json/schema/generator/GeneratorOptions.java
+++ b/generator/src/main/java/org/creekservice/api/json/schema/generator/GeneratorOptions.java
@@ -18,6 +18,7 @@ package org.creekservice.api.json.schema.generator;
 
 import java.nio.file.Path;
 import java.util.Set;
+import org.creekservice.internal.json.schema.generator.output.DirectoryTreeOutputLocationStrategy;
 
 /** Options to control the {@link JsonSchemaGenerator}. */
 public interface GeneratorOptions {
@@ -90,7 +91,38 @@ public interface GeneratorOptions {
     }
 
     /**
-     * @return The directory to output schema files to.
+     * The base directory under which schema files will be written.
+     *
+     * <p>The full path to a generated schema file for a specific {@code type} is {@code
+     * outputDirectory()}{@code .resolve(}{@link #outputLocationStrategy()}{@code
+     * .outputPath(type))}
+     *
+     * @return The base directory to output schema files to.
      */
     Path outputDirectory();
+
+    /**
+     * Strategy to use for naming generated schemas
+     *
+     * <p>The full path to a generated schema file for a specific {@code type} is {@link
+     * #outputDirectory()}{@code .resolve(}{@code outputLocationStrategy()}{@code
+     * .outputPath(type))}
+     *
+     * @return strategy that controls where under the {@link #outputDirectory()} schema files will
+     *     be written.
+     */
+    default OutputLocationStrategy outputLocationStrategy() {
+        return new DirectoryTreeOutputLocationStrategy();
+    }
+
+    /** Control where generated schemas are output. */
+    interface OutputLocationStrategy {
+        /**
+         * Get the path that the schema file for a specific {@code type} should be written too.
+         *
+         * @param type the type having its schema generated
+         * @return the path the schema should be written too.
+         */
+        Path outputPath(Class<?> type);
+    }
 }

--- a/generator/src/main/java/org/creekservice/api/json/schema/generator/JsonSchemaGenerator.java
+++ b/generator/src/main/java/org/creekservice/api/json/schema/generator/JsonSchemaGenerator.java
@@ -74,7 +74,8 @@ public final class JsonSchemaGenerator {
                         .scan();
 
         final SchemaGenerator generator = new SchemaGenerator(options.subTypeScanning());
-        final SchemaWriter writer = new SchemaWriter(options.outputDirectory());
+        final SchemaWriter writer =
+                new SchemaWriter(options.outputDirectory(), options.outputLocationStrategy());
         generator.registerSubTypes(types);
         types.stream().map(generator::generateSchema).forEach(writer::write);
         LOGGER.info("Wrote {} schemas", types.size());

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/SchemaWriter.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/SchemaWriter.java
@@ -23,20 +23,24 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.creekservice.api.base.type.schema.GeneratedSchemas;
+import org.creekservice.api.json.schema.generator.GeneratorOptions.OutputLocationStrategy;
 
 /** Writes schema to a YAML file */
 public final class SchemaWriter {
 
     private static final Logger LOGGER = LogManager.getLogger(SchemaWriter.class);
 
-    private final Path outputDir;
+    private final Path rootDirectory;
+    private final OutputLocationStrategy outputLocation;
 
     /**
-     * @param outputDir the directory into which to write the schema files
+     * @param rootDirectory the root directory under which schemas are written
+     * @param outputLocation strategy used to determine where under {@code rootDirectory} generated
+     *     schema should be written.
      */
-    public SchemaWriter(final Path outputDir) {
-        this.outputDir = requireNonNull(outputDir, "outputDir");
+    public SchemaWriter(final Path rootDirectory, final OutputLocationStrategy outputLocation) {
+        this.rootDirectory = requireNonNull(rootDirectory, "rootDirectory");
+        this.outputLocation = requireNonNull(outputLocation, "outputLocation");
     }
 
     /**
@@ -47,9 +51,7 @@ public final class SchemaWriter {
     public void write(final JsonSchema<?> schema) {
         final Class<?> type = schema.type();
         try {
-            final Path fileName =
-                    GeneratedSchemas.schemaFileName(type, GeneratedSchemas.yamlExtension());
-            final Path path = outputDir.resolve(fileName);
+            final Path path = rootDirectory.resolve(outputLocation.outputPath(type));
 
             final Path parent = path.getParent();
             if (parent != null) {

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/output/DirectoryTreeOutputLocationStrategy.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/output/DirectoryTreeOutputLocationStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.json.schema.generator.output;
+
+import java.nio.file.Path;
+import org.creekservice.api.base.type.schema.GeneratedSchemas;
+import org.creekservice.api.json.schema.generator.GeneratorOptions;
+
+/**
+ * Creek output location strategy.
+ *
+ * <p>Compatible with other Creek components.
+ *
+ * <p>Schema files will be output at a path matching the package and type names of the types having
+ * schemas generated.
+ *
+ * <p>For example, given a type {@code org.acme.some.package.TheType}, the schema will be output
+ * under {@code org/acme/some/package/TheType.yaml}
+ */
+public final class DirectoryTreeOutputLocationStrategy
+        implements GeneratorOptions.OutputLocationStrategy {
+    @Override
+    public Path outputPath(final Class<?> type) {
+        return GeneratedSchemas.schemaFileName(type, GeneratedSchemas.yamlExtension());
+    }
+}

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/output/FlatDirectoryOutputLocationStrategy.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/output/FlatDirectoryOutputLocationStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.json.schema.generator.output;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.creekservice.api.base.type.schema.GeneratedSchemas;
+import org.creekservice.api.json.schema.generator.GeneratorOptions;
+
+/**
+ * Strategy for outputting schemas to a specific directory.
+ *
+ * <p>Incompatible with other Creek components!
+ *
+ * <p>Schema files will be output to a specific directory. The filename of the schema file within
+ * this directory is derived from a types full name.
+ *
+ * <p>For example, given a type {@code org.acme.some.package.TheType}, the schema will be output
+ * under {@code <output-dir>/org.acme.some.package.TheType.yaml}
+ */
+public class FlatDirectoryOutputLocationStrategy
+        implements GeneratorOptions.OutputLocationStrategy {
+
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "False positive")
+    @Override
+    public Path outputPath(final Class<?> type) {
+        return Paths.get(type.getName() + GeneratedSchemas.yamlExtension());
+    }
+}

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/cli/PicoCliParserTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/cli/PicoCliParserTest.java
@@ -18,6 +18,7 @@ package org.creekservice.internal.json.schema.generator.cli;
 
 import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,6 +30,8 @@ import java.util.Optional;
 import java.util.Set;
 import org.creekservice.api.json.schema.generator.GeneratorOptions;
 import org.creekservice.api.json.schema.generator.GeneratorOptions.TypeScanningSpec;
+import org.creekservice.internal.json.schema.generator.output.DirectoryTreeOutputLocationStrategy;
+import org.creekservice.internal.json.schema.generator.output.FlatDirectoryOutputLocationStrategy;
 import org.junit.jupiter.api.Test;
 
 class PicoCliParserTest {
@@ -82,6 +85,23 @@ class PicoCliParserTest {
                 result.map(GeneratorOptions::outputDirectory),
                 is(Optional.of(Paths.get("some/path"))));
         assertThat(result.map(GeneratorOptions::echoOnly), is(Optional.of(false)));
+        assertThat(
+                result.orElseThrow().outputLocationStrategy(),
+                is(instanceOf(DirectoryTreeOutputLocationStrategy.class)));
+    }
+
+    @Test
+    void shouldParseOutputStrategy() {
+        // Given:
+        final String[] args = minimalArgs("--output-strategy=flatDirectory");
+
+        // When:
+        final Optional<GeneratorOptions> result = PicoCliParser.parse(args);
+
+        // Then:
+        assertThat(
+                result.orElseThrow().outputLocationStrategy(),
+                is(instanceOf(FlatDirectoryOutputLocationStrategy.class)));
     }
 
     @Test
@@ -175,6 +195,8 @@ class PicoCliParserTest {
                 is(
                         Optional.of(
                                 "--output-directory=some/path"
+                                        + lineSeparator()
+                                        + "--output-strategy=directoryTree"
                                         + lineSeparator()
                                         + "--type-scanning-allowed-modules=[some.module]"
                                         + lineSeparator()

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/output/DirectoryTreeOutputLocationStrategyTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/output/DirectoryTreeOutputLocationStrategyTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.json.schema.generator.output;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DirectoryTreeOutputLocationStrategyTest {
+
+    private DirectoryTreeOutputLocationStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new DirectoryTreeOutputLocationStrategy();
+    }
+
+    @Test
+    void shouldReturnPath() {
+        assertThat(
+                strategy.outputPath(DirectoryTreeOutputLocationStrategyTest.class),
+                is(
+                        Paths.get(
+                                "org/creekservice/internal/json/schema/generator/output/DirectoryTreeOutputLocationStrategyTest.yml")));
+    }
+}

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/output/FlatDirectoryOutputLocationStrategyTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/output/FlatDirectoryOutputLocationStrategyTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.json.schema.generator.output;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FlatDirectoryOutputLocationStrategyTest {
+
+    private FlatDirectoryOutputLocationStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new FlatDirectoryOutputLocationStrategy();
+    }
+
+    @Test
+    void shouldReturnPath() {
+        assertThat(
+                strategy.outputPath(FlatDirectoryOutputLocationStrategyTest.class).toString(),
+                is(
+                        "org.creekservice.internal.json.schema.generator.output.FlatDirectoryOutputLocationStrategyTest.yml"));
+    }
+
+    @Test
+    void shouldWorkSchemaForNestedType() {
+        assertThat(
+                strategy.outputPath(Nested.class).toString(),
+                is(
+                        "org.creekservice.internal.json.schema.generator.output.FlatDirectoryOutputLocationStrategyTest$Nested.yml"));
+    }
+
+    @Test
+    void shouldWorkSchemaForLocalType() {
+        // Given:
+        final class Model {}
+
+        // Then:
+        assertThat(
+                strategy.outputPath(Model.class).toString(),
+                is(
+                        "org.creekservice.internal.json.schema.generator.output.FlatDirectoryOutputLocationStrategyTest$1Model.yml"));
+    }
+
+    private static final class Nested {}
+}

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.FormatModel.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.FormatModel.yml
@@ -1,5 +1,5 @@
 ---
-# timestamp=1652261637045
+# timestamp=1706376038152
 $schema: http://json-schema.org/draft-07/schema#
 title: Format Model
 type: object

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.JacksonModel.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.JacksonModel.yml
@@ -1,13 +1,13 @@
 ---
-# timestamp=1652261637077
+# timestamp=1706376038135
 $schema: http://json-schema.org/draft-07/schema#
-title: Simple Model
+title: Jackson Model
 type: object
 additionalProperties: false
 properties:
-  intProp:
-    type: integer
-  stringProp:
+  optional_prop:
+    type: string
+  required_prop:
     type: string
 required:
-- intProp
+- required_prop

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.JsonSchemaModel.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.JsonSchemaModel.yml
@@ -1,0 +1,27 @@
+---
+# timestamp=1706376038149
+$schema: http://json-schema.org/draft-07/schema#
+title: Custom Title
+type: object
+additionalProperties: false
+anyOf:
+- required:
+  - uuid
+- required:
+  - with_description
+properties:
+  nonEmpty:
+    type: string
+    minLength: 1
+  set:
+    type: array
+    items:
+      type: integer
+    minItems: 1
+    uniqueItems: true
+  uuid:
+    type: string
+    format: uuid
+  withDescription:
+    type: string
+    description: This property has a text description.

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.KotlinModel.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.KotlinModel.yml
@@ -1,5 +1,5 @@
 ---
-# timestamp=1652261637031
+# timestamp=1706376038137
 $schema: http://json-schema.org/draft-07/schema#
 title: Kotlin Model
 type: object

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.OptionalModel.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.OptionalModel.yml
@@ -1,0 +1,16 @@
+---
+# timestamp=1706376038136
+$schema: http://json-schema.org/draft-07/schema#
+title: Optional Model
+type: object
+additionalProperties: false
+properties:
+  nonOptional:
+    type: string
+  optional:
+    type: string
+  requiredOptional:
+    type: string
+required:
+- nonOptional
+- requiredOptional

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.RequireModel.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.RequireModel.yml
@@ -1,0 +1,13 @@
+---
+# timestamp=1706376038127
+$schema: http://json-schema.org/draft-07/schema#
+title: Require Model
+type: object
+additionalProperties: false
+properties:
+  optionalProp:
+    type: string
+  requiredProp:
+    type: string
+required:
+- requiredProp

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.SimpleModel.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.SimpleModel.yml
@@ -1,13 +1,13 @@
 ---
-# timestamp=1652261637083
+# timestamp=1706376038151
 $schema: http://json-schema.org/draft-07/schema#
-title: Jackson Model
+title: Simple Model
 type: object
 additionalProperties: false
 properties:
-  optional_prop:
-    type: string
-  required_prop:
+  intProp:
+    type: integer
+  stringProp:
     type: string
 required:
-- required_prop
+- intProp

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.Thing.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.Thing.yml
@@ -1,36 +1,36 @@
 ---
-# timestamp=1652261637068
+# timestamp=1706376038159
 $schema: http://json-schema.org/draft-07/schema#
-title: Polymorphic Model
+title: Thing
 oneOf:
-- $ref: '#/definitions/SubType1'
-- $ref: '#/definitions/SubType2'
+- $ref: '#/definitions/SmallThing'
+- $ref: '#/definitions/big'
 definitions:
-  SubType1:
+  SmallThing:
     type: object
     additionalProperties: false
     properties:
       '@type':
         type: string
         enum:
-        - type_1
-        default: type_1
-      prop1:
-        type: string
-    title: type_1
-    required:
-    - '@type'
-  SubType2:
-    type: object
-    additionalProperties: false
-    properties:
-      '@type':
-        type: string
-        enum:
-        - type_2
-        default: type_2
+        - Thing$SmallThing
+        default: Thing$SmallThing
       prop2:
         type: string
-    title: type_2
+    title: Thing$SmallThing
+    required:
+    - '@type'
+  big:
+    type: object
+    additionalProperties: false
+    properties:
+      '@type':
+        type: string
+        enum:
+        - big
+        default: big
+      prop1:
+        type: string
+    title: big
     required:
     - '@type'

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.more.PolymorphicModel.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.more.PolymorphicModel.yml
@@ -1,36 +1,36 @@
 ---
-# timestamp=1652261637008
+# timestamp=1706376038162
 $schema: http://json-schema.org/draft-07/schema#
-title: Thing
+title: Polymorphic Model
 oneOf:
-- $ref: '#/definitions/SmallThing'
-- $ref: '#/definitions/big'
+- $ref: '#/definitions/SubType1'
+- $ref: '#/definitions/SubType2'
 definitions:
-  SmallThing:
+  SubType1:
     type: object
     additionalProperties: false
     properties:
       '@type':
         type: string
         enum:
-        - Thing$SmallThing
-        default: Thing$SmallThing
-      prop2:
-        type: string
-    title: Thing$SmallThing
-    required:
-    - '@type'
-  big:
-    type: object
-    additionalProperties: false
-    properties:
-      '@type':
-        type: string
-        enum:
-        - big
-        default: big
+        - type_1
+        default: type_1
       prop1:
         type: string
-    title: big
+    title: type_1
+    required:
+    - '@type'
+  SubType2:
+    type: object
+    additionalProperties: false
+    properties:
+      '@type':
+        type: string
+        enum:
+        - type_2
+        default: type_2
+      prop2:
+        type: string
+    title: type_2
     required:
     - '@type'

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/FormatModel.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/FormatModel.yml
@@ -1,0 +1,25 @@
+---
+# timestamp=1706376038793
+$schema: http://json-schema.org/draft-07/schema#
+title: Format Model
+type: object
+additionalProperties: false
+properties:
+  date:
+    type: string
+    format: date
+  dateTime:
+    type: string
+    format: date-time
+  instant:
+    type: string
+    format: date-time
+  period:
+    type: string
+    format: duration
+  time:
+    type: string
+    format: time
+  uri:
+    type: string
+    format: uri

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/JacksonModel.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/JacksonModel.yml
@@ -1,0 +1,13 @@
+---
+# timestamp=1706376038822
+$schema: http://json-schema.org/draft-07/schema#
+title: Jackson Model
+type: object
+additionalProperties: false
+properties:
+  optional_prop:
+    type: string
+  required_prop:
+    type: string
+required:
+- required_prop

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/JsonSchemaModel.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/JsonSchemaModel.yml
@@ -1,5 +1,5 @@
 ---
-# timestamp=1652261637114
+# timestamp=1706376038835
 $schema: http://json-schema.org/draft-07/schema#
 title: Custom Title
 type: object

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/KotlinModel.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/KotlinModel.yml
@@ -1,15 +1,17 @@
 ---
+# timestamp=1706376038823
 $schema: http://json-schema.org/draft-07/schema#
-title: Optional Model
+title: Kotlin Model
 type: object
 additionalProperties: false
 properties:
-  nonOptional:
+  prop1:
     type: string
-  optional:
+  prop2:
     type: string
-  requiredOptional:
+    default: a default value
+  prop3:
     type: string
+    default: another default
 required:
-- nonOptional
-- requiredOptional
+- prop1

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/OptionalModel.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/OptionalModel.yml
@@ -1,0 +1,16 @@
+---
+# timestamp=1706376038822
+$schema: http://json-schema.org/draft-07/schema#
+title: Optional Model
+type: object
+additionalProperties: false
+properties:
+  nonOptional:
+    type: string
+  optional:
+    type: string
+  requiredOptional:
+    type: string
+required:
+- nonOptional
+- requiredOptional

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/RequireModel.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/RequireModel.yml
@@ -1,4 +1,5 @@
 ---
+# timestamp=1706376038821
 $schema: http://json-schema.org/draft-07/schema#
 title: Require Model
 type: object

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/SimpleModel.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/SimpleModel.yml
@@ -1,0 +1,13 @@
+---
+# timestamp=1706376038837
+$schema: http://json-schema.org/draft-07/schema#
+title: Simple Model
+type: object
+additionalProperties: false
+properties:
+  intProp:
+    type: integer
+  stringProp:
+    type: string
+required:
+- intProp

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/Thing.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/Thing.yml
@@ -1,0 +1,36 @@
+---
+# timestamp=1706376038814
+$schema: http://json-schema.org/draft-07/schema#
+title: Thing
+oneOf:
+- $ref: '#/definitions/SmallThing'
+- $ref: '#/definitions/big'
+definitions:
+  SmallThing:
+    type: object
+    additionalProperties: false
+    properties:
+      '@type':
+        type: string
+        enum:
+        - Thing$SmallThing
+        default: Thing$SmallThing
+      prop2:
+        type: string
+    title: Thing$SmallThing
+    required:
+    - '@type'
+  big:
+    type: object
+    additionalProperties: false
+    properties:
+      '@type':
+        type: string
+        enum:
+        - big
+        default: big
+      prop1:
+        type: string
+    title: big
+    required:
+    - '@type'

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/more/PolymorphicModel.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/more/PolymorphicModel.yml
@@ -1,0 +1,36 @@
+---
+# timestamp=1706376038819
+$schema: http://json-schema.org/draft-07/schema#
+title: Polymorphic Model
+oneOf:
+- $ref: '#/definitions/SubType1'
+- $ref: '#/definitions/SubType2'
+definitions:
+  SubType1:
+    type: object
+    additionalProperties: false
+    properties:
+      '@type':
+        type: string
+        enum:
+        - type_1
+        default: type_1
+      prop1:
+        type: string
+    title: type_1
+    required:
+    - '@type'
+  SubType2:
+    type: object
+    additionalProperties: false
+    properties:
+      '@type':
+        type: string
+        enum:
+        - type_2
+        default: type_2
+      prop2:
+        type: string
+    title: type_2
+    required:
+    - '@type'

--- a/test-types/src/main/java/module-info.java
+++ b/test-types/src/main/java/module-info.java
@@ -6,4 +6,6 @@ module creek.json.schema.test.types {
 
     exports org.creekservice.test.types to
             com.fasterxml.jackson.databind;
+    exports org.creekservice.test.types.more to
+            com.fasterxml.jackson.databind;
 }

--- a/test-types/src/main/java/org/creekservice/test/types/more/PolymorphicModel.java
+++ b/test-types/src/main/java/org/creekservice/test/types/more/PolymorphicModel.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.test.types;
+package org.creekservice.test.types.more;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;


### PR DESCRIPTION
JPMS requires resources that are accessible from outside the module to be in _unique_ and _open_ packages.

To achieve this, we introduce a `OutputLocationStrategy` option to the generator, which defaults to placing the generated schema in a directory tree that matches the package layout of the source types.

This means, if the `--output-directory` is set to the resource root of a project, the schema files are located in the same package as the source types in the resulting jar file.
