### PR TITLE
docs: replace Coveralls badge with Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Coverage Status](https://coveralls.io/repos/github/creek-service/creek-json-schema/badge.svg?branch=main)](https://coveralls.io/github/creek-service/creek-json-schema?branch=main)
+[![codecov](https://codecov.io/gh/creek-service/creek-json-schema/branch/main/graph/badge.svg)](https://codecov.io/gh/creek-service/creek-json-schema)
 [![build](https://github.com/creek-service/creek-json-schema/actions/workflows/build.yml/badge.svg)](https://github.com/creek-service/creek-json-schema/actions/workflows/build.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/org.creekservice/creek-json-schema-generator.svg)](https://central.sonatype.dev/search?q=creek-json-schema-*)
 [![CodeQL](https://github.com/creek-service/creek-json-schema/actions/workflows/codeql.yml/badge.svg)](https://github.com/creek-service/creek-json-schema/actions/workflows/codeql.yml)


### PR DESCRIPTION
## Summary

Replace the Coveralls.io coverage badge with the equivalent Codecov badge, following the migration from Coveralls to Codecov in https://github.com/creek-service/creek-release-test/pull/411.