### PR TITLE
fix: revert scala-library to 2.13.18 to fix module resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ subprojects {
         set("jsonSchemaVersion", "1.0.39")      // https://mvnrepository.com/artifact/com.kjetland/mbknor-jackson-jsonschema
         set("classGraphVersion", "4.8.184")     // https://mvnrepository.com/artifact/io.github.classgraph/classgraph
         set("kotlinVersion", "2.3.20")          // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib-common
-        set("scalaVersion", "3.8.3")
+        set("scalaVersion", "2.13.18")         // https://mvnrepository.com/artifact/org.scala-lang/scala-library
 
         set("log4jVersion", "2.25.4")           // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
         set("guavaVersion", "33.6.0-jre")         // https://mvnrepository.com/artifact/com.google.guava/guava


### PR DESCRIPTION
## Problem

Dependabot PR #562 bumped `org.scala-lang:scala-library` from `2.13.18` to `3.8.3` (Scala 3). This crossed the Scala 2 → 3 major version boundary and broke the generator module.

The generator's `module-info.java` declares:
```java
requires scala.library;
```

This is the Automatic-Module-Name of the **Scala 2** library jar. Scala 3 uses a different module name (`scala3.library`), so the JVM boot layer fails immediately:

```
Error occurred during initialization of boot layer
java.lang.module.FindException: Module scala.library not found,
    required by creek.json.schema.generator
```

This caused 48 test failures in `creek-json-schema-gradle-plugin` (run [#24738675064](https://github.com/creek-service/creek-json-schema-gradle-plugin/actions/runs/24738675064)).

## Fix

Revert `scalaVersion` back to `2.13.18` until the generator and its module descriptor are updated to properly support Scala 3.

## Related
- Fixes regression introduced by #562