### PR TITLE
fix: revert scala-library to 2.13.18 and pin to 2.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,14 @@ updates:
     open-pull-requests-limit: 50
     schedule:
       interval: monthly
+    ignore:
+      # scala-library is a transitive security pin for mbknor-jackson-jsonschema (Scala 2).
+      # Scala 3 ships a scala-library jar that lacks Automatic-Module-Name, so Gradle's
+      # InferModulePath puts it on the classpath rather than the module path, breaking
+      # creek.json.schema.generator at boot-layer initialisation.  Pin to 2.x until the
+      # mbknor dependency is replaced with a Scala-3-compatible alternative.
+      - dependency-name: "org.scala-lang:scala-library"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: gradle
     directory: /buildSrc
     registries:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ subprojects {
         set("jsonSchemaVersion", "1.0.39")      // https://mvnrepository.com/artifact/com.kjetland/mbknor-jackson-jsonschema
         set("classGraphVersion", "4.8.184")     // https://mvnrepository.com/artifact/io.github.classgraph/classgraph
         set("kotlinVersion", "2.3.20")          // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib-common
-        set("scalaVersion", "3.8.3")
+        set("scalaVersion", "2.13.18")         // https://mvnrepository.com/artifact/org.scala-lang/scala-library
 
         set("log4jVersion", "2.25.4")           // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
         set("guavaVersion", "33.6.0-jre")         // https://mvnrepository.com/artifact/com.google.guava/guava


### PR DESCRIPTION
## Problem

Dependabot PR #562 bumped `org.scala-lang:scala-library` from `2.13.18` to `3.8.3`. Although this artifact exists on Maven Central (Scala 3 reuses the same group/artifact ID), the Scala 3 JAR does **not** include an `Automatic-Module-Name` manifest entry (unlike Scala 2 which explicitly sets `Automatic-Module-Name: scala.library`).

Gradle's `InferModulePath` uses the presence of `Automatic-Module-Name` or `module-info.class` to decide whether to place a JAR on the module path or the classpath. With Scala 3, the JAR lands on the classpath, so when `creek-json-schema-gradle-plugin` launches the generator subprocess with `--module-path`, the JVM boot layer fails:

```
Error occurred during initialization of boot layer
java.lang.module.FindException: Module scala.library not found,
    required by creek.json.schema.generator
```

This caused **48/196 test failures** in `creek-json-schema-gradle-plugin` across all tested Gradle versions (see [run #24738675064](https://github.com/creek-service/creek-json-schema-gradle-plugin/actions/runs/24738675064)).

Note: the `creek-json-schema` build itself passes because its own tests don't launch the generator via `--module-path`.

## Root Cause

The `scala-library` dependency is **not** a direct code dependency on Scala. It is a transitive security override to ensure a version of Scala 2 beyond CVE-2022-36944 is used (required by `com.kjetland:mbknor-jackson-jsonschema_2.13`). The generator does not use Scala 3 APIs.

## Fix

1. **Revert `scalaVersion` to `2.13.18`** — the latest stable Scala 2.13.x release
2. **Add a Dependabot ignore rule** to prevent future major-version bumps of `org.scala-lang:scala-library` until the mbknor dependency is replaced with a Scala-3-compatible alternative

## Related
- Caused by #562 (Dependabot major-version bump)
- Fixes failing builds in creek-service/creek-json-schema-gradle-plugin