### PR TITLE
fix: use CREEK_PACKAGES_TOKEN secret for GitHub Packages Dependabot auth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ registries:
     type: maven-repository
     url: https://maven.pkg.github.com/creek-service/
     username: x-access-token
-    password: ${{secrets.GITHUB_TOKEN}}
+    password: ${{secrets.CREEK_PACKAGES_TOKEN}}
 updates:
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
fix: use CREEK_PACKAGES_TOKEN secret for GitHub Packages Dependabot auth

GITHUB_TOKEN is an invalid Dependabot secret name (names cannot start with GITHUB_). Replace with CREEK_PACKAGES_TOKEN org-level Dependabot secret which has read:packages scope for the creek-service org.