### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@
   <!-- See https://checkstyle.org/config_header.html   -->
   <module name="RegexpHeader">
     <property name="header"
-            value="/\*\n\* Copyright (\d\d\d\d-)?2025 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
+            value="/\*\n\* Copyright (\d\d\d\d-)?2026 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
   </module>
 
   <module name="TreeWalker">

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/spotbugs/suppressions.xml
+++ b/config/spotbugs/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/api/json/schema/generator/GeneratorOptions.java
+++ b/generator/src/main/java/org/creekservice/api/json/schema/generator/GeneratorOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/api/json/schema/generator/JsonSchemaGenerator.java
+++ b/generator/src/main/java/org/creekservice/api/json/schema/generator/JsonSchemaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/JsonSchema.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/JsonSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactory.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/PolymorphicTypes.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/PolymorphicTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/SchemaGenerator.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/SchemaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/SchemaWriter.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/SchemaWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/cli/PicoCliParser.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/cli/PicoCliParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/output/DirectoryTreeOutputLocationStrategy.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/output/DirectoryTreeOutputLocationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/output/FlatDirectoryOutputLocationStrategy.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/output/FlatDirectoryOutputLocationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/resources/log4j2.xml
+++ b/generator/src/main/resources/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/ModuleTest.java
+++ b/generator/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/api/json/schema/generator/GeneratorOptionsTest.java
+++ b/generator/src/test/java/org/creekservice/api/json/schema/generator/GeneratorOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorFunctionalTest.java
+++ b/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorTest.java
+++ b/generator/src/test/java/org/creekservice/api/json/schema/generator/JsonSchemaGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/PolymorphicTypesTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/PolymorphicTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/SchemaGeneratorTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/SchemaGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/SchemaWriterTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/SchemaWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/cli/PicoCliParserTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/cli/PicoCliParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/output/DirectoryTreeOutputLocationStrategyTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/output/DirectoryTreeOutputLocationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/output/FlatDirectoryOutputLocationStrategyTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/output/FlatDirectoryOutputLocationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/build.gradle.kts
+++ b/test-types/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/src/main/java/org/creekservice/test/types/FormatModel.java
+++ b/test-types/src/main/java/org/creekservice/test/types/FormatModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/src/main/java/org/creekservice/test/types/JacksonModel.java
+++ b/test-types/src/main/java/org/creekservice/test/types/JacksonModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/src/main/java/org/creekservice/test/types/JsonSchemaModel.java
+++ b/test-types/src/main/java/org/creekservice/test/types/JsonSchemaModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/src/main/java/org/creekservice/test/types/OptionalModel.java
+++ b/test-types/src/main/java/org/creekservice/test/types/OptionalModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/src/main/java/org/creekservice/test/types/RequireModel.java
+++ b/test-types/src/main/java/org/creekservice/test/types/RequireModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/src/main/java/org/creekservice/test/types/SimpleModel.java
+++ b/test-types/src/main/java/org/creekservice/test/types/SimpleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/src/main/java/org/creekservice/test/types/Thing.java
+++ b/test-types/src/main/java/org/creekservice/test/types/Thing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/src/main/java/org/creekservice/test/types/more/PolymorphicModel.java
+++ b/test-types/src/main/java/org/creekservice/test/types/more/PolymorphicModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-types/src/main/kotlin/org/creekservice/test/types/KotlinModel.kt
+++ b/test-types/src/main/kotlin/org/creekservice/test/types/KotlinModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update checkstyle header rule and existing copyright headers from 2025 to 2026.

Note: `./gradlew static` could not be fully verified locally as main source compilation requires SNAPSHOT dependencies not yet published (expected during active development). All copyright headers have been verified correct via manual grep.