### PR TITLE
Implement network nt schema validator

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -19,10 +19,6 @@ plugins {
     application
 }
 
-repositories {
-    // For net.jimblackler.jsonschemafriend:core:
-    maven { url = uri("https://jitpack.io")  }
-}
 
 val creekVersion : String by extra
 val picoCliVersion : String by extra
@@ -52,7 +48,7 @@ dependencies {
 
     testImplementation(project(":test-types"))
     testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
-    testImplementation("net.jimblackler.jsonschemafriend:core:0.12.3")
+    testImplementation(project(":validator"))
 }
 
 application {

--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactory.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactory.java
@@ -76,6 +76,29 @@ final class JsonSchemaGeneratorFactory {
     private static final String NUMBER = "number";
     private static final String STRING = "string";
 
+    /** ISO 8601 local time pattern (no date/timezone): e.g. {@code 14:30:00.5} */
+    private static final String LOCAL_TIME_PATTERN =
+            "^(?:[01]\\d|2[0-3]):(?:[0-5]\\d)(?::(?:[0-5]\\d)(?:\\.\\d{1,9})?)?$";
+
+    /** ISO 8601 local date-time pattern (no timezone): e.g. {@code 2026-05-14T15:34:56.466} */
+    private static final String LOCAL_DATE_TIME_PATTERN =
+            "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])"
+                    + "T(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d{1,9})?)?$";
+
+    /** ISO 8601 period pattern (date part only, no time): e.g. {@code P1Y2M3D} */
+    private static final String PERIOD_PATTERN =
+            "^P(?=\\d)(?:\\d+Y)?(?:\\d+M)?(?:\\d+W)?(?:\\d+D)?$";
+
+    /** ISO 8601 month-day pattern: e.g. {@code --05-14} */
+    private static final String MONTH_DAY_PATTERN =
+            "^--(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])$";
+
+    /** ISO 8601 year-month pattern: e.g. {@code 2026-05} */
+    private static final String YEAR_MONTH_PATTERN = "^-?\\d{4,}-(?:0[1-9]|1[0-2])$";
+
+    /** ISO 8601 year pattern: e.g. {@code 2026} */
+    private static final String YEAR_PATTERN = "^-?\\d+$";
+
     private static final ObjectMapper JSON_MAPPER = JsonMapper.builder().build();
 
     private static final Map<Class<?>, Mapping> TYPE_MAPPINGS =
@@ -85,14 +108,12 @@ final class JsonSchemaGeneratorFactory {
                     entry(URI.class, Mapping.toType(STRING).withDefaultFormat("uri")),
                     entry(
                             LocalTime.class,
-                            Mapping.toType(STRING)
-                                    .withDefaultPattern(
-                                            "^(?:[01]\\d|2[0-3]):(?:[0-5]\\d)(?::(?:[0-5]\\d)(?:\\.\\d{1,9})?)?$")),
+                            Mapping.toType(STRING).withDefaultPattern(LOCAL_TIME_PATTERN)),
                     entry(OffsetTime.class, Mapping.toType(STRING).withDefaultFormat("time")),
                     entry(LocalDate.class, Mapping.toType(STRING).withDefaultFormat("date")),
                     entry(
                             LocalDateTime.class,
-                            Mapping.toType(STRING).withDefaultFormat("date-time")),
+                            Mapping.toType(STRING).withDefaultPattern(LOCAL_DATE_TIME_PATTERN)),
                     entry(
                             OffsetDateTime.class,
                             Mapping.toType(STRING).withDefaultFormat("date-time")),
@@ -105,18 +126,14 @@ final class JsonSchemaGeneratorFactory {
                             Period.class,
                             Mapping.toType(STRING)
                                     .withDefaultFormat("duration")
-                                    .withDefaultPattern(
-                                            "^P(?=\\d)(?:\\d+Y)?(?:\\d+M)?(?:\\d+W)?(?:\\d+D)?$")),
+                                    .withDefaultPattern(PERIOD_PATTERN)),
                     entry(
                             MonthDay.class,
-                            Mapping.toType(STRING)
-                                    .withDefaultPattern(
-                                            "^--(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])$")),
+                            Mapping.toType(STRING).withDefaultPattern(MONTH_DAY_PATTERN)),
                     entry(
                             YearMonth.class,
-                            Mapping.toType(STRING)
-                                    .withDefaultPattern("^-?\\d{4,}-(?:0[1-9]|1[0-2])$")),
-                    entry(Year.class, Mapping.toType(STRING).withDefaultPattern("^-?\\d+$")),
+                            Mapping.toType(STRING).withDefaultPattern(YEAR_MONTH_PATTERN)),
+                    entry(Year.class, Mapping.toType(STRING).withDefaultPattern(YEAR_PATTERN)),
                     entry(
                             byte.class,
                             Mapping.toType(INTEGER)

--- a/generator/src/test/java/module-info.test
+++ b/generator/src/test/java/module-info.test
@@ -1,8 +1,8 @@
 --add-modules
-  org.junitpioneer,org.mockito.junit.jupiter,org.hamcrest,com.google.common.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,creek.json.schema.test.types,jimblackler.jsonschemafriend.core,com.fasterxml.jackson.datatype.jsr310
+  org.junitpioneer,org.mockito.junit.jupiter,org.hamcrest,com.google.common.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,creek.json.schema.test.types,creek.json.schema.validator,com.fasterxml.jackson.datatype.jsr310
 
 --add-reads
-  creek.json.schema.generator=org.junitpioneer,org.mockito.junit.jupiter,org.hamcrest,com.google.common.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,creek.json.schema.test.types,jimblackler.jsonschemafriend.core,com.fasterxml.jackson.datatype.jsr310
+  creek.json.schema.generator=org.junitpioneer,org.mockito.junit.jupiter,org.hamcrest,com.google.common.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,creek.json.schema.test.types,creek.json.schema.validator,com.fasterxml.jackson.datatype.jsr310
 
 --add-opens
   org.junitpioneer/org.junitpioneer.jupiter=org.junit.platform.commons

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactoryTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactoryTest.java
@@ -68,12 +68,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import net.jimblackler.jsonschemafriend.Schema;
-import net.jimblackler.jsonschemafriend.SchemaStore;
-import net.jimblackler.jsonschemafriend.ValidationException;
-import net.jimblackler.jsonschemafriend.Validator;
 import org.creek.test.MinimalClassSub;
 import org.creekservice.api.base.annotation.schema.JsonSchemaInject;
+import org.creekservice.api.json.schema.validator.JsonSchemaValidator;
+import org.creekservice.api.json.schema.validator.SchemaValidationException;
 import org.junit.jupiter.api.Test;
 
 @SuppressFBWarnings()
@@ -596,21 +594,23 @@ class JsonSchemaGeneratorFactoryTest {
     }
 
     @Test
-    void shouldInsertLocalDateTimeAsStringWithDateTimeFormat() {
+    void shouldInsertLocalDateTimeAsStringWithPatternButNoFormat() {
         // When:
         final String result = generateSchema(TypeWithLocalDateTime.class);
 
         // Then:
+        // Todo: Include the expected pattern here:
         assertThat(
                 result,
                 containsString(
                         """
                           date:
                             type: string
-                            format: date-time\
+                            pattern:\
                         """));
 
         assertThat(result, not(containsString("LocalDateTime")));
+        assertThat(result, not(containsString("format: date-time")));
 
         assertAlignsWithJackson(
                 result,
@@ -1403,14 +1403,10 @@ class JsonSchemaGeneratorFactoryTest {
     }
 
     @SafeVarargs
+    @SuppressWarnings("varargs")
     private <T> void assertAlignsWithJackson(
             final String yaml, final Class<T> type, final T... instances) {
-        final Schema parsedSchema = assertCanParse(yaml);
-        for (final T instance : instances) {
-            final String json = assertCanSerialize(instance);
-            assertValidJson(json, parsedSchema, yaml);
-            assertCanDeserialize(type, json, instance);
-        }
+        assertAlignsWithJackson(yaml, type, List.of(instances), List.of());
     }
 
     private <T> void assertAlignsWithJackson(
@@ -1418,24 +1414,22 @@ class JsonSchemaGeneratorFactoryTest {
             final Class<T> type,
             final Collection<T> validInstances,
             final Collection<T> invalidInstances) {
-        final Schema parsedSchema = assertCanParse(yaml);
+        final JsonSchemaValidator validator = assertCanParseSchema(yaml);
         for (final T instance : validInstances) {
             final String json = assertCanSerialize(instance);
-            assertValidJson(json, parsedSchema, yaml);
+            assertValidJson(json, validator, yaml);
             assertCanDeserialize(type, json, instance);
         }
 
         for (final T instance : invalidInstances) {
             final String json = assertCanSerialize(instance);
-            assertInvalidJson(json, parsedSchema, yaml);
+            assertInvalidJson(json, validator, yaml);
         }
     }
 
-    private Schema assertCanParse(final String yaml) {
+    private JsonSchemaValidator assertCanParseSchema(final String yaml) {
         try {
-            final Object obj = yamlMapper.readValue(yaml, Object.class);
-            final SchemaStore schemaStore = new SchemaStore(true);
-            return schemaStore.loadSchema(obj);
+            return JsonSchemaValidator.fromSchema(yaml);
         } catch (final Exception e) {
             throw new AssertionError("Invalid schema: " + yaml, e);
         }
@@ -1449,10 +1443,12 @@ class JsonSchemaGeneratorFactoryTest {
         }
     }
 
-    private void assertValidJson(final String json, final Schema parsedSchema, final String yaml) {
+    private void assertValidJson(
+            final String json, final JsonSchemaValidator validator, final String yaml) {
         try {
-            final Object o = jsonMapper.readValue(json, Object.class);
-            new Validator(true).validate(parsedSchema, o);
+            final Map<String, ?> props =
+                    jsonMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+            validator.validate(props);
         } catch (final Exception e) {
             throw new AssertionError(
                     "Invalid JSON: " + json + System.lineSeparator() + "Schema: " + yaml, e);
@@ -1460,24 +1456,24 @@ class JsonSchemaGeneratorFactoryTest {
     }
 
     private void assertInvalidJson(
-            final String json, final Schema parsedSchema, final String yaml) {
-        final Object o;
+            final String json, final JsonSchemaValidator validator, final String yaml) {
+        final Map<String, ?> props;
 
         try {
-            o = jsonMapper.readValue(json, Object.class);
+            props = jsonMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
         } catch (final Exception e) {
             throw new AssertionError("Invalid JSON: " + json, e);
         }
 
         try {
-            new Validator(true).validate(parsedSchema, o);
+            validator.validate(props);
             throw new AssertionError(
                     "Invalid JSON not detected: "
                             + json
                             + System.lineSeparator()
                             + "Schema: "
                             + yaml);
-        } catch (final ValidationException e) {
+        } catch (final SchemaValidationException e) {
             // Expected
         }
     }

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/SchemaGeneratorTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/SchemaGeneratorTest.java
@@ -29,24 +29,22 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import net.jimblackler.jsonschemafriend.Schema;
-import net.jimblackler.jsonschemafriend.SchemaStore;
-import net.jimblackler.jsonschemafriend.Validator;
 import org.creekservice.api.json.schema.generator.GeneratorOptions.TypeScanningSpec;
+import org.creekservice.api.json.schema.validator.JsonSchemaValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -75,9 +73,6 @@ class SchemaGeneratorTest {
                     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                     .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                     .build();
-
-    private final ObjectMapper yamlMapper =
-            new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES));
 
     private SchemaGenerator generator;
 
@@ -337,19 +332,17 @@ class SchemaGeneratorTest {
 
     @SafeVarargs
     private <T> void assertAlignsWithJackson(final JsonSchema<T> schema, final T... instances) {
-        final Schema parsedSchema = assertCanParse(schema);
+        final JsonSchemaValidator validator = assertCanParse(schema);
         for (final T instance : instances) {
             final String json = assertCanSerialize(instance);
-            assertValidJson(json, parsedSchema, schema);
+            assertValidJson(json, validator, schema);
             assertCanDeserialize(schema, json, instance);
         }
     }
 
-    private <T> Schema assertCanParse(final JsonSchema<T> schema) {
+    private <T> JsonSchemaValidator assertCanParse(final JsonSchema<T> schema) {
         try {
-            final Object obj = yamlMapper.readValue(schema.text(), Object.class);
-            final SchemaStore schemaStore = new SchemaStore(true);
-            return schemaStore.loadSchema(obj);
+            return JsonSchemaValidator.fromSchema(schema.text());
         } catch (final Exception e) {
             throw new AssertionError("Invalid schema: " + schema.text(), e);
         }
@@ -364,10 +357,11 @@ class SchemaGeneratorTest {
     }
 
     private void assertValidJson(
-            final String json, final Schema parsedSchema, final JsonSchema<?> schema) {
+            final String json, final JsonSchemaValidator validator, final JsonSchema<?> schema) {
         try {
-            final Object o = jsonMapper.readValue(json, Object.class);
-            new Validator(true).validate(parsedSchema, o);
+            final Map<String, ?> props =
+                    jsonMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+            validator.validate(props);
         } catch (final Exception e) {
             throw new AssertionError(
                     "Invalid JSON: " + json + System.lineSeparator() + "Schema: " + schema.text(),

--- a/validator/build.gradle.kts
+++ b/validator/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-rootProject.name = "creek-json-schema"
+plugins {
+    `java-library`
+}
 
-include(
-    "generator",
-    "test-types",
-    "validator"
-)
+val jacksonVersion : String by extra
+
+dependencies {
+    implementation("com.networknt:json-schema-validator:2.0.1")
+    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+}

--- a/validator/src/main/java/module-info.java
+++ b/validator/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+/** Module for validating JSON data against JSON Schemas. */
+module creek.json.schema.validator {
+    requires com.networknt.schema;
+    requires com.fasterxml.jackson.databind;
+
+    exports org.creekservice.api.json.schema.validator;
+}

--- a/validator/src/main/java/org/creekservice/api/json/schema/validator/JsonSchemaValidator.java
+++ b/validator/src/main/java/org/creekservice/api/json/schema/validator/JsonSchemaValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.json.schema.validator;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import org.creekservice.internal.json.schema.validator.NetworkntJsonSchemaValidator;
+
+/**
+ * Validates JSON data against a JSON Schema.
+ *
+ * <p>Wraps the networknt json-schema-validator library, keeping its types out of the public API.
+ * Format assertions are enabled, matching real-world ISO 8601 behaviour (e.g. {@code "PT0.5S"} is
+ * accepted for sub-second durations).
+ */
+public final class JsonSchemaValidator {
+
+    private final NetworkntJsonSchemaValidator internal;
+
+    private JsonSchemaValidator(final NetworkntJsonSchemaValidator internal) {
+        this.internal = requireNonNull(internal, "internal");
+    }
+
+    /**
+     * Create a validator from a YAML or JSON schema string.
+     *
+     * <p>Because YAML is a superset of JSON, this method accepts either format.
+     *
+     * @param schema the schema content, in YAML or JSON format.
+     * @return a new validator instance.
+     * @throws SchemaValidationException if the schema cannot be parsed.
+     */
+    public static JsonSchemaValidator fromSchema(final String schema) {
+        return new JsonSchemaValidator(NetworkntJsonSchemaValidator.fromSchema(schema));
+    }
+
+    /**
+     * Validate the supplied object properties against the schema.
+     *
+     * @param objectProperties the object's properties, as returned by Jackson deserialisation.
+     * @throws SchemaValidationException if validation fails.
+     */
+    public void validate(final Map<String, ?> objectProperties) {
+        internal.validate(objectProperties);
+    }
+}

--- a/validator/src/main/java/org/creekservice/api/json/schema/validator/SchemaValidationException.java
+++ b/validator/src/main/java/org/creekservice/api/json/schema/validator/SchemaValidationException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.json.schema.validator;
+
+/** Thrown when JSON data fails schema validation, or when a schema cannot be parsed. */
+public final class SchemaValidationException extends RuntimeException {
+
+    /**
+     * Create an exception with a message.
+     *
+     * @param message description of the failure.
+     * @return a new exception.
+     */
+    public static SchemaValidationException of(final String message) {
+        return new SchemaValidationException(message, null);
+    }
+
+    /**
+     * Create an exception with a message and a cause.
+     *
+     * @param message description of the failure.
+     * @param cause the underlying cause.
+     * @return a new exception.
+     */
+    public static SchemaValidationException of(final String message, final Throwable cause) {
+        return new SchemaValidationException(message, cause);
+    }
+
+    private SchemaValidationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/validator/src/main/java/org/creekservice/internal/json/schema/validator/NetworkntJsonSchemaValidator.java
+++ b/validator/src/main/java/org/creekservice/internal/json/schema/validator/NetworkntJsonSchemaValidator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.json.schema.validator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.Error;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SchemaRegistryConfig;
+import com.networknt.schema.SpecificationVersion;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.creekservice.api.json.schema.validator.SchemaValidationException;
+
+/** Internal networknt-based implementation of JSON schema validation. */
+public final class NetworkntJsonSchemaValidator {
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    private static final SchemaRegistry REGISTRY =
+            SchemaRegistry.withDefaultDialect(
+                    SpecificationVersion.DRAFT_2020_12,
+                    b ->
+                            b.schemaRegistryConfig(
+                                    SchemaRegistryConfig.builder()
+                                            .formatAssertionsEnabled(true)
+                                            .strict("duration", false)
+                                            .build()));
+
+    private final Schema schema;
+
+    private NetworkntJsonSchemaValidator(final Schema schema) {
+        this.schema = schema;
+    }
+
+    /**
+     * Create a validator from a YAML or JSON schema string.
+     *
+     * @param schemaContent the schema content.
+     * @return a new validator instance.
+     * @throws SchemaValidationException if the schema cannot be parsed.
+     */
+    public static NetworkntJsonSchemaValidator fromSchema(final String schemaContent) {
+        try {
+            final InputStream inputStream =
+                    new ByteArrayInputStream(schemaContent.getBytes(StandardCharsets.UTF_8));
+            return new NetworkntJsonSchemaValidator(
+                    REGISTRY.getSchema(inputStream, InputFormat.YAML));
+        } catch (final SchemaValidationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw SchemaValidationException.of("Failed to parse schema", e);
+        }
+    }
+
+    /**
+     * Validate the supplied object properties against the schema.
+     *
+     * @param objectProperties the object's properties to validate.
+     * @throws SchemaValidationException if validation fails.
+     */
+    public void validate(final Map<String, ?> objectProperties) {
+        try {
+            final JsonNode node = JSON_MAPPER.valueToTree(objectProperties);
+            final List<Error> errors = schema.validate(node);
+            if (!errors.isEmpty()) {
+                final String errorMsg =
+                        errors.stream().map(Error::getMessage).collect(Collectors.joining(", "));
+                throw SchemaValidationException.of("Validation failed: " + errorMsg);
+            }
+        } catch (final SchemaValidationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw SchemaValidationException.of("Validation error", e);
+        }
+    }
+}

--- a/validator/src/main/java/org/creekservice/internal/json/schema/validator/NetworkntJsonSchemaValidator.java
+++ b/validator/src/main/java/org/creekservice/internal/json/schema/validator/NetworkntJsonSchemaValidator.java
@@ -66,8 +66,6 @@ public final class NetworkntJsonSchemaValidator {
                     new ByteArrayInputStream(schemaContent.getBytes(StandardCharsets.UTF_8));
             return new NetworkntJsonSchemaValidator(
                     REGISTRY.getSchema(inputStream, InputFormat.YAML));
-        } catch (final SchemaValidationException e) {
-            throw e;
         } catch (final Exception e) {
             throw SchemaValidationException.of("Failed to parse schema", e);
         }
@@ -80,16 +78,18 @@ public final class NetworkntJsonSchemaValidator {
      * @throws SchemaValidationException if validation fails.
      */
     public void validate(final Map<String, ?> objectProperties) {
+        final List<Error> errors = doValidate(objectProperties);
+        if (!errors.isEmpty()) {
+            final String errorMsg =
+                    errors.stream().map(Error::getMessage).collect(Collectors.joining(", "));
+            throw SchemaValidationException.of("Validation failed: " + errorMsg);
+        }
+    }
+
+    private List<Error> doValidate(final Map<String, ?> objectProperties) {
         try {
             final JsonNode node = JSON_MAPPER.valueToTree(objectProperties);
-            final List<Error> errors = schema.validate(node);
-            if (!errors.isEmpty()) {
-                final String errorMsg =
-                        errors.stream().map(Error::getMessage).collect(Collectors.joining(", "));
-                throw SchemaValidationException.of("Validation failed: " + errorMsg);
-            }
-        } catch (final SchemaValidationException e) {
-            throw e;
+            return schema.validate(node);
         } catch (final Exception e) {
             throw SchemaValidationException.of("Validation error", e);
         }

--- a/validator/src/test/java/module-info.test
+++ b/validator/src/test/java/module-info.test
@@ -1,0 +1,14 @@
+--add-modules
+  org.junitpioneer,org.mockito.junit.jupiter,org.hamcrest,com.google.common.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity
+
+--add-reads
+  creek.json.schema.validator=org.junitpioneer,org.mockito.junit.jupiter,org.hamcrest,com.google.common.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity
+
+--add-opens
+  org.junitpioneer/org.junitpioneer.jupiter=org.junit.platform.commons
+
+--add-opens
+  java.base/java.lang=org.junitpioneer
+
+--add-opens
+  java.base/java.util=org.junitpioneer

--- a/validator/src/test/java/org/creekservice/ModuleTest.java
+++ b/validator/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-rootProject.name = "creek-json-schema"
+package org.creekservice;
 
-include(
-    "generator",
-    "test-types",
-    "validator"
-)
+import org.creekservice.api.test.conformity.ConformityTester;
+import org.junit.jupiter.api.Test;
+
+class ModuleTest {
+
+    @Test
+    void shouldConform() {
+        ConformityTester.test(ModuleTest.class);
+    }
+}

--- a/validator/src/test/java/org/creekservice/api/json/schema/validator/JsonSchemaValidatorTest.java
+++ b/validator/src/test/java/org/creekservice/api/json/schema/validator/JsonSchemaValidatorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.json.schema.validator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class JsonSchemaValidatorTest {
+
+    private static final String SIMPLE_SCHEMA_YAML =
+            """
+            $schema: https://json-schema.org/draft/2020-12/schema
+            type: object
+            properties:
+              name:
+                type: string
+              age:
+                type: integer
+            required:
+            - name
+            """;
+
+    private static final String DURATION_SCHEMA_YAML =
+            """
+            $schema: https://json-schema.org/draft/2020-12/schema
+            type: object
+            properties:
+              duration:
+                type: string
+                format: duration
+            required:
+            - duration
+            """;
+
+    @Test
+    void shouldParseValidYamlSchema() {
+        JsonSchemaValidator.fromSchema(SIMPLE_SCHEMA_YAML);
+    }
+
+    @Test
+    void shouldParseValidJsonSchema() {
+        // Given:
+        final String jsonSchema =
+                """
+                {"$schema":"https://json-schema.org/draft/2020-12/schema",\
+                "type":"object","properties":{"name":{"type":"string"}}}\
+                """;
+
+        // Then: should not throw:
+        JsonSchemaValidator.fromSchema(jsonSchema);
+    }
+
+    @Test
+    void shouldThrowOnInvalidSchema() {
+        assertThrows(
+                SchemaValidationException.class,
+                () -> JsonSchemaValidator.fromSchema("not: [valid: schema: content: [[["));
+    }
+
+    @Test
+    void shouldPassValidationForConformingData() {
+        // Given:
+        final JsonSchemaValidator validator = JsonSchemaValidator.fromSchema(SIMPLE_SCHEMA_YAML);
+
+        // Then: should not throw:
+        validator.validate(Map.of("name", "Alice", "age", 30));
+    }
+
+    @Test
+    void shouldFailValidationForNonConformingData() {
+        // Given:
+        final JsonSchemaValidator validator = JsonSchemaValidator.fromSchema(SIMPLE_SCHEMA_YAML);
+
+        // When:
+        final SchemaValidationException ex =
+                assertThrows(
+                        SchemaValidationException.class,
+                        () -> validator.validate(Map.of("age", "not-an-integer")));
+
+        // Then:
+        assertThat(ex.getMessage(), containsString("Validation failed"));
+    }
+
+    @Test
+    void shouldFailValidationForMissingRequiredField() {
+        // Given:
+        final JsonSchemaValidator validator = JsonSchemaValidator.fromSchema(SIMPLE_SCHEMA_YAML);
+
+        // When:
+        final SchemaValidationException ex =
+                assertThrows(
+                        SchemaValidationException.class,
+                        () -> validator.validate(Map.of("age", 42)));
+
+        // Then:
+        assertThat(ex.getMessage(), containsString("Validation failed"));
+    }
+
+    @Test
+    void shouldAcceptSubSecondDuration() {
+        // Schema draft strictly doesn't allow sub-second duration, but this is very limiting.
+        // Ongoing discussion will hopefully resolve this in the next draft:
+        // See https://github.com/json-schema-org/json-schema-spec/issues/1603
+
+        // Given:
+        final JsonSchemaValidator validator = JsonSchemaValidator.fromSchema(DURATION_SCHEMA_YAML);
+
+        // Then: does not throw:
+        validator.validate(Map.of("duration", "PT0.5S"));
+    }
+
+    @Test
+    void shouldEnforceFormatAssertions() {
+        // Given:
+        final JsonSchemaValidator validator = JsonSchemaValidator.fromSchema(DURATION_SCHEMA_YAML);
+
+        // When:
+        final SchemaValidationException ex =
+                assertThrows(
+                        SchemaValidationException.class,
+                        () -> validator.validate(Map.of("duration", "not-a-duration")));
+
+        // Then:
+        assertThat(ex.getMessage(), containsString("Validation failed"));
+    }
+}


### PR DESCRIPTION
Move from `net.jimblackler.jsonschemafriend` to `com.networknt:json-schema-validator`.

This performs much better than JSF, (See https://www.creekservice.org/json-schema-validation-comparison/), and is more actively maintained.
