### PR TITLE
Add support for `OptionalLong`, `OptionalInt` and `OptionalDouble`.

### DIFF
--- a/generator/src/main/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactory.java
+++ b/generator/src/main/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactory.java
@@ -61,6 +61,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import org.creekservice.api.base.annotation.schema.JsonSchemaInject;
 import tools.jackson.databind.BeanDescription;
 import tools.jackson.databind.ObjectMapper;
@@ -247,9 +250,20 @@ final class JsonSchemaGeneratorFactory {
     }
 
     private static List<ResolvedType> unwrapOptionalReturnType(final MethodScope method) {
-        return method.getType().isInstanceOf(Optional.class)
-                ? List.of(method.getTypeParameterFor(Optional.class, 0))
-                : null;
+        final Class<?> erasedType = method.getType().getErasedType();
+        if (erasedType == Optional.class) {
+            return List.of(method.getTypeParameterFor(Optional.class, 0));
+        }
+        if (erasedType == OptionalInt.class) {
+            return List.of(method.getContext().resolve(int.class));
+        }
+        if (erasedType == OptionalLong.class) {
+            return List.of(method.getContext().resolve(long.class));
+        }
+        if (erasedType == OptionalDouble.class) {
+            return List.of(method.getContext().resolve(double.class));
+        }
+        return null;
     }
 
     private static Optional<BeanPropertyDefinition> findJacksonProperty(

--- a/generator/src/test/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactoryTest.java
+++ b/generator/src/test/java/org/creekservice/internal/json/schema/generator/JsonSchemaGeneratorFactoryTest.java
@@ -54,6 +54,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.UUID;
 import org.creek.test.MinimalClassSub;
 import org.creekservice.api.base.annotation.schema.JsonSchemaInject;
@@ -1255,6 +1258,35 @@ class JsonSchemaGeneratorFactoryTest {
     }
 
     @Test
+    void shouldHandleOptionalPrimitiveProperties() {
+        // When:
+        final String result = generateSchema(ModelWithOptionalPrimitives.class);
+
+        // Then:
+        final Map<String, ?> parsedSchema = parseYaml(result);
+        assertThat(yamlGet(parsedSchema, "properties", "intVal", "type"), is("integer"));
+        assertThat(yamlGet(parsedSchema, "properties", "intVal", "minimum"), is(-2147483648));
+        assertThat(yamlGet(parsedSchema, "properties", "intVal", "maximum"), is(2147483647));
+        assertThat(yamlGet(parsedSchema, "properties", "longVal", "type"), is("integer"));
+        assertThat(
+                yamlGet(parsedSchema, "properties", "longVal", "minimum"),
+                is(-9223372036854775808L));
+        assertThat(
+                yamlGet(parsedSchema, "properties", "longVal", "maximum"),
+                is(9223372036854775807L));
+        assertThat(yamlGet(parsedSchema, "properties", "doubleVal", "type"), is("number"));
+        assertThat(result, not(containsString("required")));
+
+        assertAlignsWithJackson(
+                result,
+                ModelWithOptionalPrimitives.class,
+                new ModelWithOptionalPrimitives(
+                        OptionalInt.empty(), OptionalLong.empty(), OptionalDouble.empty()),
+                new ModelWithOptionalPrimitives(
+                        OptionalInt.of(42), OptionalLong.of(42L), OptionalDouble.of(3.14)));
+    }
+
+    @Test
     void shouldHandleSingleCharGetters() {
         // Given:
         final String schema = generateSchema(TypeWithSingleCharGetters.class);
@@ -1718,6 +1750,9 @@ class JsonSchemaGeneratorFactoryTest {
     public record ModelWithOptionalProperty(Optional<String> thing) {}
 
     public record ModelWithWildcardOptionalProperty(Optional<?> thing) {}
+
+    public record ModelWithOptionalPrimitives(
+            OptionalInt intVal, OptionalLong longVal, OptionalDouble doubleVal) {}
 
     @SuppressWarnings("ClassCanBeRecord")
     public static final class TypeWithJsonGetter {

--- a/generator/src/test/resources/schemas/flat/org.creekservice.test.types.OptionalPrimitivesModel.yml
+++ b/generator/src/test/resources/schemas/flat/org.creekservice.test.types.OptionalPrimitivesModel.yml
@@ -1,0 +1,17 @@
+---
+# timestamp=0
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  optionalDouble:
+    type: number
+  optionalInt:
+    type: integer
+    minimum: -2147483648
+    maximum: 2147483647
+  optionalLong:
+    type: integer
+    minimum: -9223372036854775808
+    maximum: 9223372036854775807
+title: Optional Primitives Model
+additionalProperties: false

--- a/generator/src/test/resources/schemas/tree/org/creekservice/test/types/OptionalPrimitivesModel.yml
+++ b/generator/src/test/resources/schemas/tree/org/creekservice/test/types/OptionalPrimitivesModel.yml
@@ -1,0 +1,17 @@
+---
+# timestamp=0
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  optionalDouble:
+    type: number
+  optionalInt:
+    type: integer
+    minimum: -2147483648
+    maximum: 2147483647
+  optionalLong:
+    type: integer
+    minimum: -9223372036854775808
+    maximum: 9223372036854775807
+title: Optional Primitives Model
+additionalProperties: false

--- a/test-types/src/main/java/org/creekservice/test/types/OptionalPrimitivesModel.java
+++ b/test-types/src/main/java/org/creekservice/test/types/OptionalPrimitivesModel.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.test.types;
+
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import org.creekservice.api.base.annotation.schema.GeneratesSchema;
+
+@SuppressWarnings("unused") // Invoked via reflection
+@GeneratesSchema
+public record OptionalPrimitivesModel(
+        OptionalInt optionalInt, OptionalLong optionalLong, OptionalDouble optionalDouble) {}


### PR DESCRIPTION
Schema generator now supports `OptionalLong`, `OptionalInt` and `OptionalDouble` along side existing `Optional` support.
